### PR TITLE
Install doesn't seem to be working possibly due to psychopy dependencies

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,19 +7,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@master
     - uses: actions/checkout@master
-      with:
-        fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
     - name: Dependencies
       run: |
+        git fetch origin gh-pages  # checkout depth=1 doesn't include this branch
         python -m pip install --upgrade pip
         pip install furo  # furo theme for sphinx
         pip install numpy
-        pip install git+https://github.com/psychopy/psychopy-lib
-        pip install .
+        pip install git+https://github.com/psychopy/psychopy-lib --prefer-binary
+
+    - name: Install self
+        pip install -e .
+
     - name: Build and Commit
       uses: sphinx-notes/pages@v2
+
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:


### PR DESCRIPTION
Trying to get binary wheels to install using pip --prefer-binary This will install an older version with a wheel in preference to a newer source-only option